### PR TITLE
ci: drop EOL Python 3.9/3.10, require Python 3.11+

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.11', '3.12']
 
     steps:
     - uses: actions/checkout@v6

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ For merged overlays (when using `--merge-overlays` flag):
 
 ## Requirements
 
-- Python 3.7+
+- Python 3.11+
 - `requests` library (installed automatically by setup.sh)
 - `Pillow` library (for overlay merging and EXIF metadata, installed automatically by setup.sh)
 - `piexif` library (for EXIF metadata embedding, installed automatically by setup.sh)


### PR DESCRIPTION
## Why
The dependency floors in `requirements.txt` have moved past Python 3.9/3.10, which is what's turning CI red on the open Dependabot PRs (#24–#28):

| Package | Bumped to | Requires |
|---------|-----------|----------|
| Pillow | 12.2.0 | >=3.10 |
| requests | 2.33.1 | >=3.10 |
| PyQt6 | 6.11.0 | >=3.10 |
| timezonefinder | 8.2.2 | **>=3.11** |
| pytz | 2026.1 | (any) |

The CI matrix still tested `3.9, 3.10, 3.11, 3.12`, so `pip install -r requirements.txt` fails on the old interpreters (no compatible wheel) and the whole matrix goes red via fail-fast. The test code itself is fine — all 46 tests pass locally on 3.9 and 3.12.

## What
- Narrow the CI matrix to `3.11, 3.12`.
- Document **Python 3.11+** as the minimum in the README.

Python 3.9 is already past end-of-life (Oct 2025); 3.10 reaches EOL Oct 2026. This unblocks the Dependabot bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)