### PR TITLE
Support new bundled-media Snapchat export format (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,14 @@ Before using this tool, you need to download your data from Snapchat:
    - Review all 8 types and select what you need
 5. Click **"Submit Request"**
 6. Wait for Snapchat to email you (can take 24-48 hours)
-7. Download the ZIP file from the email
-8. Extract it - you'll find `memories_history.html` in the `html/` folder
+7. Download the ZIP file(s) from the email
+8. Extract it - your media is in the `memories/` folder (new format) or you'll
+   find `memories_history.html` in the `html/` folder (older format)
+
+> ⏳ **Download promptly — exports now appear to expire ~3 days after you request
+> them.** Snapchat used to give ~7 days; recent exports seem to lapse in about 3.
+> Grab all the ZIP files as soon as the email arrives, or you may have to request
+> your data again. New exports can also be several GB split across multiple ZIPs.
 
 **Note:** Chat Media and Shared Stories used to be included with Memories,
 but are now separate options at the bottom of the list.
@@ -98,6 +104,12 @@ with its `-overlay`, merging them, and copying GPS/timestamps from
 Visit the [web version](https://andrefecto.github.io/Snapchat-Memories-Downloader/)
 and upload your `memories_history.html` file. Everything runs in your browser -
 your data never leaves your device!
+
+**New bundled-media export?** If your export has no "Download" links and the media
+is already inside a `memories` folder, click **"Choose Export Folder"** instead and
+select your unzipped export. The tool pairs `-main`/`-overlay` files, merges them in
+your browser, and downloads a single ZIP. (Very large libraries may hit browser
+memory limits — use the Python version for those.)
 
 ### Options
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,23 @@ but are now separate options at the bottom of the list.
 
 [More info on Reddit](https://www.reddit.com/r/techsupport/comments/18mkfvv/is_there_a_way_of_exporting_all_snapchat/)
 
+### Two export formats
+
+Snapchat ships Memories exports in one of two ways, and this tool handles both:
+
+- **Old format (download links):** the export's `html/memories_history.html` has a
+  **Download** link per memory and the actual media lives on Snapchat's servers.
+  The tool downloads each file (the original behavior).
+- **New format (media bundled in, ~2026):** the export already contains your media
+  on disk inside a `memories/` folder (files named `..._-main.<ext>` plus optional
+  `..._-overlay.<ext>`), and the download column reads `N/A`. Nothing needs to be
+  downloaded — but Snapchat still does **not** merge overlays onto your photos/videos.
+
+If your export is the new bundled format and you point the tool at the export folder,
+it **auto-detects** it and switches to local processing — pairing each `-main` file
+with its `-overlay`, merging them, and copying GPS/timestamps from
+`json/memories_history.json`. See [New bundled-media exports](#-new-bundled-media-exports).
+
 ## Why Use This FREE Tool?
 
 ### 💰 Don't Pay for What Should Be Free
@@ -198,6 +215,44 @@ python download_memories.py --retry-failed
 ```
 
 ### Advanced Features
+
+#### 📦 New bundled-media exports
+
+If your Snapchat export already contains your media on disk (the new ~2026 format —
+a `memories/` folder full of `..._-main.<ext>` files and a download column that reads
+`N/A`), just point the tool at the **export folder** and it auto-detects it:
+
+```bash
+# Auto-detected — no download links needed
+python download_memories.py /path/to/unzipped-export
+
+# Or force it explicitly
+python download_memories.py /path/to/unzipped-export --local-export
+```
+
+**What this does (no network access):**
+
+- ✅ Pairs each `-main` file with its matching `-overlay` (by filename)
+- ✅ Merges overlays onto the base photo/video (the part Snapchat still skips)
+- ✅ Reads date + GPS from `json/memories_history.json` and embeds EXIF / video metadata
+- ✅ Sets each file's modification time to the original capture date
+- ✅ Writes results to `processed_memories/` — **your export is never modified**
+
+**Useful options:**
+
+```bash
+# Keep -main/-overlay separate instead of merging
+python download_memories.py /path/to/export --no-merge
+
+# Local-timezone metadata, timestamp filenames, only items that have overlays
+python download_memories.py /path/to/export --local-timezone --timestamp-filenames --overlays-only
+
+# Custom output folder
+python download_memories.py /path/to/export -o ./my-merged-memories
+```
+
+> Video overlay merging requires FFmpeg (see [Setup](#setup)). Without it, videos are
+> copied and their `-overlay` kept alongside so you can merge later.
 
 #### 🌍 Timezone-Aware Metadata
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -579,6 +579,28 @@
       <label for="fileInput" class="btn">Choose HTML File</label>
       <p id="fileName" style="margin-top: 15px; color: #667eea; font-weight: 600"></p>
 
+      <!-- New bundled-media export (~2026): media already on disk, no download links -->
+      <div style="
+            margin-top: 25px;
+            padding: 16px;
+            border: 1px dashed #667eea;
+            border-radius: 8px;
+            background: #f6f7ff;
+          ">
+        <h4 style="margin-bottom: 6px; font-size: 16px">
+          📦 New Snapchat export? (media already included)
+        </h4>
+        <p style="color: #666; margin-bottom: 12px; font-size: 14px">
+          If your export has no "Download" links and the photos/videos are already
+          inside a <code>memories</code> folder, choose the unzipped export folder
+          instead. Overlays are merged in your browser and downloaded as a ZIP — your
+          files never leave your computer.
+        </p>
+        <input type="file" id="folderInput" webkitdirectory directory multiple />
+        <label for="folderInput" class="btn" style="background: #667eea">Choose Export Folder</label>
+        <p id="folderName" style="margin-top: 10px; color: #667eea; font-weight: 600"></p>
+      </div>
+
       <div style="
             margin-top: 25px;
             padding-top: 20px;
@@ -2406,6 +2428,15 @@
       }
     });
 
+    const folderInput = document.getElementById("folderInput");
+    if (folderInput) {
+      folderInput.addEventListener("change", (e) => {
+        if (e.target.files.length > 0) {
+          handleExportFolder(e.target.files);
+        }
+      });
+    }
+
     metadataInput.addEventListener("change", async (e) => {
       if (e.target.files.length > 0) {
         const file = e.target.files[0];
@@ -2652,6 +2683,351 @@
       startButton.style.display = "inline-block";
     }
 
+    // ====================================================================
+    // NEW EXPORT FORMAT (~2026): media bundled locally (GitHub issue #23)
+    // Folder-picker path: the user selects the unzipped export folder; we pair
+    // each -main file with its -overlay (filename convention), merge them, embed
+    // EXIF/metadata from json/memories_history.json, and download a ZIP. No
+    // network access. Mirrors process_local_export() in download_memories.py.
+    // ====================================================================
+    let localExportMode = false;
+    let localExportMemories = [];
+
+    function pathBasename(path) {
+      return (path || "").split("/").pop();
+    }
+
+    function isVideoName(name) {
+      return /\.(mp4|mov|avi|m4v)$/i.test(name || "");
+    }
+
+    function safeParseSnapchatDate(dateStr) {
+      if (!dateStr || dateStr === "Unknown") return null;
+      try {
+        const d = parseSnapchatDate(dateStr);
+        return isNaN(d.getTime()) ? null : d;
+      } catch (e) {
+        return null;
+      }
+    }
+
+    function datePrefixFromName(name) {
+      const m = (name || "").match(/^(\d{4}-\d{2}-\d{2})/);
+      return m ? m[1] : null;
+    }
+
+    /** Normalize json/memories_history.json text into memory metadata. */
+    function parseMemoriesJsonText(text) {
+      let data;
+      try {
+        data = JSON.parse(text);
+      } catch (e) {
+        return [];
+      }
+      const entries =
+        data && Array.isArray(data["Saved Media"]) ? data["Saved Media"] : [];
+      return entries.map((entry) => {
+        const date = ((entry["Date"] || "Unknown") + "").trim() || "Unknown";
+        const mediaType =
+          ((entry["Media Type"] || "Unknown") + "").trim() || "Unknown";
+        let latitude = "Unknown";
+        let longitude = "Unknown";
+        const loc = entry["Location"] || "";
+        const m = loc.match(/Latitude,\s*Longitude:\s*([-\d.]+),\s*([-\d.]+)/);
+        if (m) {
+          latitude = m[1];
+          longitude = m[2];
+        }
+        return { date, mediaType, latitude, longitude };
+      });
+    }
+
+    /** Ordered list of -main filenames referenced by memories.html. */
+    function parseGalleryMainOrderText(text) {
+      const order = [];
+      const re = /src\s*=\s*"([^"]*?-main\.[^"]+)"/g;
+      let m;
+      while ((m = re.exec(text)) !== null) order.push(pathBasename(m[1]));
+      return order;
+    }
+
+    /** Ingest a chosen export folder and build localExportMemories[]. */
+    async function handleExportFolder(fileList) {
+      const files = Array.from(fileList || []);
+      if (files.length === 0) return;
+
+      const mainFiles = [];
+      const overlaysByBase = {};
+      let jsonFile = null;
+      let galleryFile = null;
+
+      for (const f of files) {
+        const path = f.webkitRelativePath || f.name;
+        const name = pathBasename(path);
+        if (name === "memories_history.json") jsonFile = f;
+        if (name === "memories.html" && path.includes("memories/"))
+          galleryFile = f;
+        const ov = name.match(/^(.*)-overlay\.[^.]+$/i);
+        if (ov) overlaysByBase[ov[1]] = f;
+        else if (/-main\.[^.]+$/i.test(name)) mainFiles.push(f);
+      }
+
+      if (mainFiles.length === 0) {
+        addLog(
+          "No '*-main.*' media files found in that folder. If your export has " +
+            "Download links instead, use the 'Choose HTML File' option above.",
+          "error"
+        );
+        document.getElementById("folderName").textContent =
+          "Not a bundled-media export (no -main files found).";
+        return;
+      }
+
+      // Order main files by the gallery when available, then append the rest.
+      const mainByName = {};
+      for (const f of mainFiles)
+        mainByName[pathBasename(f.webkitRelativePath || f.name)] = f;
+
+      const ordered = [];
+      const seen = new Set();
+      if (galleryFile) {
+        const galleryText = await galleryFile.text();
+        for (const nm of parseGalleryMainOrderText(galleryText)) {
+          const f = mainByName[nm];
+          if (f && !seen.has(nm)) {
+            ordered.push(f);
+            seen.add(nm);
+          }
+        }
+      }
+      for (const f of mainFiles) {
+        const nm = pathBasename(f.webkitRelativePath || f.name);
+        if (!seen.has(nm)) {
+          ordered.push(f);
+          seen.add(nm);
+        }
+      }
+
+      const meta = jsonFile ? parseMemoriesJsonText(await jsonFile.text()) : [];
+      const aligned = meta.length === ordered.length;
+      if (meta.length && !aligned) {
+        addLog(
+          `Warning: ${ordered.length} media files but ${meta.length} JSON entries; ` +
+            "cannot match GPS/time by order — using filename dates.",
+          "warning"
+        );
+      }
+
+      localExportMemories = ordered.map((mainFile, i) => {
+        const name = pathBasename(mainFile.webkitRelativePath || mainFile.name);
+        const base = name.slice(0, name.lastIndexOf("-main"));
+        const overlayFile = overlaysByBase[base] || null;
+        let entry = aligned && meta[i] ? meta[i] : {};
+        let date = entry.date || "Unknown";
+
+        // Cross-check the JSON date against the filename's date prefix.
+        const fileDate = datePrefixFromName(name);
+        if (entry.date && date !== "Unknown" && fileDate && !date.startsWith(fileDate)) {
+          addLog(
+            `Warning: date mismatch for ${name} (JSON '${date}' vs filename ` +
+              `'${fileDate}'); using filename date.`,
+            "warning"
+          );
+          entry = {};
+          date = "Unknown";
+        }
+        if (date === "Unknown" && fileDate) date = `${fileDate} 00:00:00 UTC`;
+
+        return {
+          mainFile,
+          overlayFile,
+          date,
+          mediaType:
+            entry.mediaType ||
+            (isVideoName(name) ? "Video" : "Image"),
+          latitude: entry.latitude || "Unknown",
+          longitude: entry.longitude || "Unknown",
+        };
+      });
+
+      localExportMode = true;
+      const withOverlay = localExportMemories.filter((m) => m.overlayFile).length;
+      addLog(
+        `Detected new export format: ${localExportMemories.length} memories ` +
+          `(${withOverlay} with overlays)${jsonFile ? "" : " — no JSON metadata found"}.`,
+        "success"
+      );
+      document.getElementById("folderName").textContent =
+        `${localExportMemories.length} memories ready (${withOverlay} with overlays). Click "Start" to merge & download.`;
+      uploadSection.style.display = "none";
+      startButton.style.display = "inline-block";
+    }
+
+    /** Process a chosen new-format export: merge, embed metadata, download ZIP. */
+    async function processLocalExport() {
+      const merge = document.getElementById("mergeOverlaysCheckbox").checked;
+      const overlaysOnly = document.getElementById("overlaysOnlyCheckbox").checked;
+      const videosOnly = document.getElementById("videosOnlyCheckbox").checked;
+      const picturesOnly = document.getElementById("picturesOnlyCheckbox").checked;
+      const useTimestamp = document.getElementById("timestampFilenamesCheckbox").checked;
+
+      const exportZip = new JSZip();
+      const metadataList = [];
+      const total = localExportMemories.length;
+      let merged = 0;
+      let copied = 0;
+      let skipped = 0;
+      let errors = 0;
+
+      addLog(`\nProcessing ${total} memories from local export...`, "info");
+
+      for (let i = 0; i < total; i++) {
+        if (shouldStop) {
+          addLog("⏸ Stopped — packaging what was processed so far.", "warning");
+          break;
+        }
+        const mem = localExportMemories[i];
+        const mainName = pathBasename(
+          mem.mainFile.webkitRelativePath || mem.mainFile.name
+        );
+        const ext = mainName.slice(mainName.lastIndexOf("."));
+        const isVideo = isVideoName(mainName);
+
+        if (
+          (videosOnly && !isVideo) ||
+          (picturesOnly && isVideo) ||
+          (overlaysOnly && !mem.overlayFile)
+        ) {
+          skipped++;
+          continue;
+        }
+
+        const outName =
+          useTimestamp && mem.date !== "Unknown"
+            ? generateFilename(mem.date, ext, true, String(i + 1).padStart(2, "0"))
+            : mainName.replace("-main", "");
+
+        status.textContent = `[${i + 1}/${total}] ${mainName}`;
+        addLog(`[${i + 1}/${total}] ${mainName}`, "info");
+
+        const entry = {
+          number: i + 1,
+          date: mem.date,
+          media_type: mem.mediaType,
+          latitude: mem.latitude,
+          longitude: mem.longitude,
+          source_main: mainName,
+          source_overlay: mem.overlayFile
+            ? pathBasename(mem.overlayFile.webkitRelativePath || mem.overlayFile.name)
+            : null,
+        };
+
+        try {
+          let outData = await mem.mainFile.arrayBuffer();
+          let didMerge = false;
+          const fileDate = safeParseSnapchatDate(mem.date);
+          const zipOpts = {};
+          if (fileDate) zipOpts.date = fileDate;
+
+          if (isVideo) {
+            if (mem.overlayFile && merge) {
+              const overlayName = pathBasename(
+                mem.overlayFile.webkitRelativePath || mem.overlayFile.name
+              );
+              const overlayExt = overlayName.slice(overlayName.lastIndexOf("."));
+              const overlayIsImage = !isVideoName(overlayName);
+              const overlayData = await mem.overlayFile.arrayBuffer();
+              addLog("  Merging video overlay (FFmpeg.wasm)...", "info");
+              const result = await mergeVideoOverlay(
+                outData,
+                overlayData,
+                null,
+                overlayIsImage,
+                overlayExt
+              );
+              if (result) {
+                outData = result;
+                didMerge = true;
+              } else {
+                addLog(
+                  "  Video merge unavailable; saving main + overlay separately.",
+                  "warning"
+                );
+                const ovOut = overlayName.replace("-main", "");
+                exportZip.file(ovOut, overlayData, {
+                  ...zipOpts,
+                  compression: "STORE",
+                });
+                entry.overlay_saved_separately = ovOut;
+              }
+            }
+            try {
+              outData = await addVideoMetadata(
+                outData,
+                mem.date,
+                mem.latitude,
+                mem.longitude
+              );
+            } catch (e) {
+              // Non-fatal: keep the video without container metadata.
+            }
+            // Videos are already compressed — STORE avoids breaking playback.
+            exportZip.file(outName, outData, { ...zipOpts, compression: "STORE" });
+          } else {
+            if (mem.overlayFile && merge) {
+              const overlayData = await mem.overlayFile.arrayBuffer();
+              outData = await mergeImageOverlay(outData, overlayData);
+              didMerge = true;
+            }
+            outData = await addExifMetadata(
+              outData,
+              mem.date,
+              mem.latitude,
+              mem.longitude
+            );
+            exportZip.file(outName, outData, zipOpts);
+          }
+
+          entry.status = "success";
+          entry.type = didMerge ? "merged" : "single";
+          entry.files = [{ path: outName, type: entry.type }];
+          if (didMerge) merged++;
+          else copied++;
+          addLog(`  ${didMerge ? "Merged" : "Saved"}: ${outName}`, "success");
+        } catch (error) {
+          errors++;
+          entry.status = "failed";
+          entry.error = error.message;
+          addLog(`  ERROR: ${error.message}`, "error");
+        }
+
+        metadataList.push(entry);
+        progressFill.style.width = `${Math.round(((i + 1) / total) * 100)}%`;
+      }
+
+      exportZip.file(
+        "metadata.json",
+        JSON.stringify(
+          { settings: { source: "local-export" }, memories: metadataList },
+          null,
+          2
+        )
+      );
+
+      status.textContent = "Creating ZIP...";
+      addLog("\n📦 Packaging snapchat-memories-merged.zip...", "info");
+      const blob = await exportZip.generateAsync({ type: "blob" });
+      downloadBlob(blob, "snapchat-memories-merged.zip");
+
+      addLog(
+        `\n✅ Done! ${merged} merged, ${copied} copied, ${skipped} skipped, ${errors} errors.`,
+        "success"
+      );
+      status.textContent = "Complete!";
+      stopButton.style.display = "none";
+      startButton.style.display = "inline-block";
+    }
+
     function handleStartDownload() {
       // Reset stop flag
       shouldStop = false;
@@ -2660,6 +3036,16 @@
       startButton.style.display = "none";
       stopButton.style.display = "inline-block";
       progressContainer.style.display = "block";
+
+      // New bundled-media export path (folder picker) vs. classic URL download.
+      if (localExportMode) {
+        processLocalExport().catch((err) => {
+          addLog(`Fatal error: ${err.message}`, "error");
+          stopButton.style.display = "none";
+          startButton.style.display = "inline-block";
+        });
+        return;
+      }
 
       // Start the download
       startDownload();

--- a/docs/index.html
+++ b/docs/index.html
@@ -2809,46 +2809,53 @@
       }
 
       const meta = jsonFile ? parseMemoriesJsonText(await jsonFile.text()) : [];
-      const aligned = meta.length === ordered.length;
-      if (meta.length && !aligned) {
-        addLog(
-          `Warning: ${ordered.length} media files but ${meta.length} JSON entries; ` +
-            "cannot match GPS/time by order — using filename dates.",
-          "warning"
-        );
+
+      // Match each file to a JSON entry that shares its capture DATE. The JSON has
+      // no filename field AND lists entries newest-first while the gallery/files are
+      // oldest-first, so positional alignment would mismatch everything. Grouping by
+      // date is direction-agnostic; within a date, entries are consumed in
+      // chronological order, lining up with the gallery's chronological order.
+      const byDate = {};
+      const sortedMeta = meta
+        .slice()
+        .sort((a, b) => (a.date < b.date ? -1 : a.date > b.date ? 1 : 0));
+      for (const m of sortedMeta) {
+        const day = datePrefixFromName(m.date);
+        if (!day) continue;
+        (byDate[day] = byDate[day] || []).push(m);
       }
 
-      localExportMemories = ordered.map((mainFile, i) => {
+      let unmatched = 0;
+      localExportMemories = ordered.map((mainFile) => {
         const name = pathBasename(mainFile.webkitRelativePath || mainFile.name);
         const base = name.slice(0, name.lastIndexOf("-main"));
         const overlayFile = overlaysByBase[base] || null;
-        let entry = aligned && meta[i] ? meta[i] : {};
-        let date = entry.date || "Unknown";
 
-        // Cross-check the JSON date against the filename's date prefix.
-        const fileDate = datePrefixFromName(name);
-        if (entry.date && date !== "Unknown" && fileDate && !date.startsWith(fileDate)) {
-          addLog(
-            `Warning: date mismatch for ${name} (JSON '${date}' vs filename ` +
-              `'${fileDate}'); using filename date.`,
-            "warning"
-          );
-          entry = {};
-          date = "Unknown";
-        }
-        if (date === "Unknown" && fileDate) date = `${fileDate} 00:00:00 UTC`;
+        const fileDay = datePrefixFromName(name);
+        const queue = fileDay ? byDate[fileDay] : null;
+        const entry = queue && queue.length ? queue.shift() : {};
+        if (!entry.date && meta.length) unmatched++;
+
+        let date = entry.date || "Unknown";
+        if (date === "Unknown" && fileDay) date = `${fileDay} 00:00:00 UTC`;
 
         return {
           mainFile,
           overlayFile,
           date,
           mediaType:
-            entry.mediaType ||
-            (isVideoName(name) ? "Video" : "Image"),
+            entry.mediaType || (isVideoName(name) ? "Video" : "Image"),
           latitude: entry.latitude || "Unknown",
           longitude: entry.longitude || "Unknown",
         };
       });
+      if (unmatched) {
+        addLog(
+          `Warning: ${unmatched} media file(s) had no JSON entry for their date; ` +
+            "using filename date only (no GPS).",
+          "warning"
+        );
+      }
 
       localExportMode = true;
       const withOverlay = localExportMemories.filter((m) => m.overlayFile).length;

--- a/docs/index.html
+++ b/docs/index.html
@@ -2866,7 +2866,6 @@
       );
       document.getElementById("folderName").textContent =
         `${localExportMemories.length} memories ready (${withOverlay} with overlays). Click "Start" to merge & download.`;
-      uploadSection.style.display = "none";
       startButton.style.display = "inline-block";
     }
 

--- a/download_memories.py
+++ b/download_memories.py
@@ -2189,9 +2189,10 @@ def process_local_export(
             out_name = main_file.name.replace('-main', '')
         out_file = output_path / out_name
 
-        has_gps = mem['latitude'] != 'Unknown' and mem['longitude'] != 'Unknown'
+        # Log only the on-disk filename (which already carries the date) + overlay;
+        # the date/GPS/timestamp are recorded in metadata.json and embedded in the
+        # files. Avoid echoing parsed date/location to stdout.
         print(f"\n[{idx}/{len(memories)}] {main_file.name}")
-        print(f"  Date: {mem['date']} | Type: {media_type} | GPS: {'yes' if has_gps else 'no'}")
         if overlay_file:
             print(f"  Overlay: {overlay_file.name}")
 
@@ -2253,7 +2254,7 @@ def process_local_export(
                 os.utime(out_file, (src_stat.st_atime, src_stat.st_mtime))
 
             size = out_file.stat().st_size
-            print(f"  {'Merged' if did_merge else 'Saved'}: {out_name} ({size:,} bytes)")
+            print(f"  {'Merged' if did_merge else 'Saved'} ({size:,} bytes)")
             entry['status'] = 'success'
             entry['type'] = 'merged' if did_merge else 'single'
             entry['files'] = [{'path': out_name, 'size': size,

--- a/download_memories.py
+++ b/download_memories.py
@@ -33,6 +33,7 @@ import io
 import subprocess
 import hashlib
 import shutil
+from collections import defaultdict, deque
 
 INVALID_FILENAME_CHARS = '<>:"/\\|?*'
 
@@ -2059,10 +2060,15 @@ def build_local_memories(layout: dict) -> list:
     """Build the ordered list of memories to process from a new-format export.
 
     Each item: {main_file, overlay_file, date, media_type, latitude, longitude}.
-    Files are ordered by the gallery (memories.html) when available, then aligned
-    by index with the JSON metadata. When counts disagree the date prefix in each
-    filename is used as a fallback so timestamps stay correct even if GPS can't be
-    matched.
+
+    Files are ordered by the gallery (memories.html, chronological) when available,
+    else by filename. Each file is matched to a JSON metadata entry that shares its
+    capture DATE (the JSON has no filename field, and - importantly - its entries are
+    ordered newest-first while the gallery/files are oldest-first, so positional
+    alignment would mismatch everything). Matching by date is direction-agnostic:
+    within a date, entries are consumed in chronological order, which lines up with
+    the gallery's chronological order. Files with no matching JSON entry fall back to
+    the filename's date (no GPS), so timestamps stay correct regardless.
     """
     media_dir = layout['media_dir']
     main_files = sorted(media_dir.glob('*-main.*'))
@@ -2082,28 +2088,25 @@ def build_local_memories(layout: dict) -> list:
             ordered_mains.append(f)
             seen.add(f.name)
 
+    # Group JSON metadata by capture date; each group is a chronological queue.
     meta_entries = parse_memories_json(layout['json_file']) if layout['json_file'] else []
-    aligned = len(meta_entries) == len(ordered_mains)
-    if meta_entries and not aligned:
-        print(f"  Warning: {len(ordered_mains)} media files but {len(meta_entries)} JSON "
-              f"entries - cannot reliably match GPS/time by order; using filename dates.")
+    by_date = defaultdict(deque)
+    for m in sorted(meta_entries, key=lambda e: e['date']):
+        day = _date_prefix_from_name(m['date'])
+        if day:
+            by_date[day].append(m)
 
     memories = []
-    for idx, main_file in enumerate(ordered_mains):
-        meta = meta_entries[idx] if (aligned and idx < len(meta_entries)) else {}
+    unmatched = 0
+    for main_file in ordered_mains:
+        file_day = _date_prefix_from_name(main_file.name)
+        meta = by_date[file_day].popleft() if (file_day and by_date.get(file_day)) else {}
+        if not meta and meta_entries:
+            unmatched += 1
+
         date = meta.get('date', 'Unknown')
-
-        # Cross-check the indexed JSON date against the filename's date prefix.
-        # On mismatch, trust the filename (avoids attaching the wrong GPS/time).
-        file_date = _date_prefix_from_name(main_file.name)
-        if meta and date != 'Unknown' and file_date and not date.startswith(file_date):
-            print(f"  Warning: date mismatch for {main_file.name} "
-                  f"(JSON '{date}' vs filename '{file_date}'); using filename date.")
-            meta = {}
-            date = 'Unknown'
-
-        if date == 'Unknown' and file_date:
-            date = f"{file_date} 00:00:00 UTC"
+        if date == 'Unknown' and file_day:
+            date = f"{file_day} 00:00:00 UTC"
 
         memories.append({
             'main_file': main_file,
@@ -2113,6 +2116,13 @@ def build_local_memories(layout: dict) -> list:
             'latitude': meta.get('latitude', 'Unknown'),
             'longitude': meta.get('longitude', 'Unknown'),
         })
+
+    if unmatched:
+        print(f"  Warning: {unmatched} media file(s) had no JSON entry for their date; "
+              f"used the filename date only (no GPS).")
+    leftover = sum(len(q) for q in by_date.values())
+    if leftover:
+        print(f"  Note: {leftover} JSON metadata entr(ies) had no matching media file.")
     return memories
 
 

--- a/download_memories.py
+++ b/download_memories.py
@@ -2189,9 +2189,9 @@ def process_local_export(
             out_name = main_file.name.replace('-main', '')
         out_file = output_path / out_name
 
+        has_gps = mem['latitude'] != 'Unknown' and mem['longitude'] != 'Unknown'
         print(f"\n[{idx}/{len(memories)}] {main_file.name}")
-        print(f"  Date: {mem['date']} | Type: {media_type} | "
-              f"Location: {mem['latitude']}, {mem['longitude']}")
+        print(f"  Date: {mem['date']} | Type: {media_type} | GPS: {'yes' if has_gps else 'no'}")
         if overlay_file:
             print(f"  Overlay: {overlay_file.name}")
 

--- a/download_memories.py
+++ b/download_memories.py
@@ -32,6 +32,7 @@ import zipfile
 import io
 import subprocess
 import hashlib
+import shutil
 
 INVALID_FILENAME_CHARS = '<>:"/\\|?*'
 
@@ -1898,6 +1899,377 @@ def merge_existing_files(folder_path: str) -> None:
     print("\nNote: Original -main and -overlay files were NOT deleted")
 
 
+# ============================================================================
+# NEW EXPORT FORMAT (2026+) - locally-bundled media
+# ============================================================================
+# As of ~2026 Snapchat ships Memories already downloaded INSIDE the export
+# instead of providing per-row download URLs. The old html/memories_history.html
+# still exists, but its download column now reads "N/A" - which is why the
+# URL-based parser reports "No memories found" (GitHub issue #23).
+#
+# New export layout (after unzipping):
+#   <root>/index.html
+#   <root>/html/memories_history.html    (table; download column is now "N/A")
+#   <root>/json/memories_history.json    ({"Saved Media": [{Date, Media Type, Location, ...}]})
+#   <root>/memories/memories.html        (gallery referencing local files)
+#   <root>/memories/<YYYY-MM-DD>_<UUID>-main.<ext>   (+ optional matching -overlay)
+#
+# This path processes that local export with NO network access: it pairs each
+# -main file with its -overlay (filename convention, same as --merge-existing),
+# merges overlays (still the tool's core value-add - Snapchat ships them
+# UNmerged), and enriches EXIF/timestamps from json/memories_history.json.
+
+NEW_EXPORT_MEDIA_DIRNAME = 'memories'
+VIDEO_SUFFIXES = ('.mp4', '.mov', '.avi', '.m4v')
+
+
+def _media_type_from_suffix(suffix: str) -> str:
+    """Best-effort media type from a file extension."""
+    return 'Video' if suffix.lower() in VIDEO_SUFFIXES else 'Image'
+
+
+def _date_prefix_from_name(name: str) -> Optional[str]:
+    """Extract the leading YYYY-MM-DD date from a memory filename, if present."""
+    match = re.match(r'(\d{4}-\d{2}-\d{2})', name)
+    return match.group(1) if match else None
+
+
+def locate_export_layout(input_path: str) -> Optional[dict]:
+    """Locate the pieces of a new-format (bundled-media) Snapchat export.
+
+    Accepts a path to the export root, the memories/ folder, or any of the
+    bundled HTML files (index.html / memories.html / memories_history.html).
+
+    Returns {root, media_dir, gallery_html, json_file} if the path looks like a
+    new-format export (a folder containing *-main.* media files), else None.
+    """
+    p = Path(input_path)
+
+    # Build a list of candidate base directories to inspect.
+    candidates = []
+    if p.is_file():
+        candidates += [p.parent, p.parent.parent]
+    elif p.is_dir():
+        candidates += [p, p.parent]
+    else:
+        return None
+
+    for base in candidates:
+        if base is None:
+            continue
+        # The media directory is either a memories/ subfolder or the base itself,
+        # identified by the presence of at least one *-main.* file.
+        media_dir = None
+        for cand in (base / NEW_EXPORT_MEDIA_DIRNAME, base):
+            if cand.is_dir() and next(cand.glob('*-main.*'), None) is not None:
+                media_dir = cand
+                break
+        if media_dir is None:
+            continue
+
+        root = media_dir.parent if media_dir.name == NEW_EXPORT_MEDIA_DIRNAME else media_dir
+        gallery = media_dir / 'memories.html'
+        json_file = None
+        for cand in (
+            root / 'json' / 'memories_history.json',
+            root / 'memories_history.json',
+            media_dir / 'memories_history.json',
+        ):
+            if cand.is_file():
+                json_file = cand
+                break
+
+        return {
+            'root': root,
+            'media_dir': media_dir,
+            'gallery_html': gallery if gallery.is_file() else None,
+            'json_file': json_file,
+        }
+
+    return None
+
+
+def parse_memories_json(json_path: Path) -> list:
+    """Parse json/memories_history.json into normalized metadata dicts.
+
+    Output keys match the rest of the tool: date, media_type, latitude, longitude.
+    The new export leaves the download fields empty, so they are ignored here.
+    """
+    try:
+        with open(json_path, 'r', encoding='utf-8') as f:
+            data = json.load(f)
+    except (OSError, json.JSONDecodeError) as e:
+        print(f"  Warning: Could not read {json_path}: {e}")
+        return []
+
+    entries = data.get('Saved Media', []) if isinstance(data, dict) else []
+    memories = []
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        date = (entry.get('Date') or 'Unknown').strip() or 'Unknown'
+        media_type = (entry.get('Media Type') or 'Unknown').strip() or 'Unknown'
+        latitude = longitude = 'Unknown'
+        location = entry.get('Location') or ''
+        loc_match = re.search(r'Latitude,\s*Longitude:\s*([-\d.]+),\s*([-\d.]+)', location)
+        if loc_match:
+            latitude, longitude = loc_match.group(1), loc_match.group(2)
+        memories.append({
+            'date': date,
+            'media_type': media_type,
+            'latitude': latitude,
+            'longitude': longitude,
+        })
+    return memories
+
+
+def parse_gallery_main_order(gallery_html: Path) -> list:
+    """Return the ordered list of -main filenames referenced in memories.html.
+
+    This preserves the order in which Snapchat lists memories, which is used to
+    align local files with json/memories_history.json entries (the JSON has no
+    filename field). Only the *-main.* references are needed; overlays are paired
+    later by filename convention.
+    """
+    try:
+        text = gallery_html.read_text(encoding='utf-8', errors='ignore')
+    except OSError:
+        return []
+    order = []
+    for match in re.finditer(r'src\s*=\s*"([^"]*?-main\.[^"]+)"', text):
+        order.append(os.path.basename(match.group(1)))
+    return order
+
+
+def find_overlay_for_main(main_file: Path) -> Optional[Path]:
+    """Find the -overlay file matching a -main file by shared base name.
+
+    e.g. 2026-05-13_<UUID>-main.mp4  ->  2026-05-13_<UUID>-overlay.png
+    The overlay may use a different extension (often .png for image overlays).
+    """
+    name = main_file.name
+    marker = '-main'
+    if marker not in name:
+        return None
+    base = name[:name.rindex(marker)]  # date + UUID portion (no glob metachars)
+    return next(iter(sorted(main_file.parent.glob(f'{base}-overlay.*'))), None)
+
+
+def build_local_memories(layout: dict) -> list:
+    """Build the ordered list of memories to process from a new-format export.
+
+    Each item: {main_file, overlay_file, date, media_type, latitude, longitude}.
+    Files are ordered by the gallery (memories.html) when available, then aligned
+    by index with the JSON metadata. When counts disagree the date prefix in each
+    filename is used as a fallback so timestamps stay correct even if GPS can't be
+    matched.
+    """
+    media_dir = layout['media_dir']
+    main_files = sorted(media_dir.glob('*-main.*'))
+    by_name = {f.name: f for f in main_files}
+
+    # Order main files by the gallery first, then append any not referenced there.
+    ordered_mains = []
+    seen = set()
+    if layout['gallery_html']:
+        for name in parse_gallery_main_order(layout['gallery_html']):
+            f = by_name.get(name)
+            if f is not None and f.name not in seen:
+                ordered_mains.append(f)
+                seen.add(f.name)
+    for f in main_files:
+        if f.name not in seen:
+            ordered_mains.append(f)
+            seen.add(f.name)
+
+    meta_entries = parse_memories_json(layout['json_file']) if layout['json_file'] else []
+    aligned = len(meta_entries) == len(ordered_mains)
+    if meta_entries and not aligned:
+        print(f"  Warning: {len(ordered_mains)} media files but {len(meta_entries)} JSON "
+              f"entries - cannot reliably match GPS/time by order; using filename dates.")
+
+    memories = []
+    for idx, main_file in enumerate(ordered_mains):
+        meta = meta_entries[idx] if (aligned and idx < len(meta_entries)) else {}
+        date = meta.get('date', 'Unknown')
+
+        # Cross-check the indexed JSON date against the filename's date prefix.
+        # On mismatch, trust the filename (avoids attaching the wrong GPS/time).
+        file_date = _date_prefix_from_name(main_file.name)
+        if meta and date != 'Unknown' and file_date and not date.startswith(file_date):
+            print(f"  Warning: date mismatch for {main_file.name} "
+                  f"(JSON '{date}' vs filename '{file_date}'); using filename date.")
+            meta = {}
+            date = 'Unknown'
+
+        if date == 'Unknown' and file_date:
+            date = f"{file_date} 00:00:00 UTC"
+
+        memories.append({
+            'main_file': main_file,
+            'overlay_file': find_overlay_for_main(main_file),
+            'date': date,
+            'media_type': meta.get('media_type') or _media_type_from_suffix(main_file.suffix),
+            'latitude': meta.get('latitude', 'Unknown'),
+            'longitude': meta.get('longitude', 'Unknown'),
+        })
+    return memories
+
+
+def process_local_export(
+    input_path: str,
+    output_dir: str = 'processed_memories',
+    merge_overlays: bool = True,
+    use_timestamp_filenames: bool = False,
+    use_local_timezone: bool = False,
+    videos_only: bool = False,
+    pictures_only: bool = False,
+    overlays_only: bool = False,
+) -> bool:
+    """Process a new-format (bundled-media) Snapchat export.
+
+    No network access: pairs -main/-overlay files, merges overlays, embeds
+    EXIF/video metadata and timestamps from json/memories_history.json, and
+    writes results to output_dir. Originals in the export are never modified.
+
+    Returns True if the input was a new-format export (and was processed),
+    False if it did not look like one (so the caller can fall back).
+    """
+    layout = locate_export_layout(input_path)
+    if layout is None:
+        return False
+
+    print("Detected new Snapchat export format (media bundled locally).")
+    print(f"  Export root: {layout['root']}")
+    print(f"  Media dir:   {layout['media_dir']}")
+    print(f"  Metadata:    {layout['json_file'] or '(none - using filename dates)'}")
+    print("=" * 60)
+
+    memories = build_local_memories(layout)
+    if not memories:
+        print("No -main media files found in the export!")
+        return True
+
+    if use_local_timezone and not timezone_support:
+        print("⚠ Timezone support disabled (missing timezonefinder/pytz); using UTC")
+        use_local_timezone = False
+
+    output_path = Path(output_dir)
+    output_path.mkdir(exist_ok=True)
+
+    metadata_list = []
+    merged_count = copied_count = skipped_count = error_count = 0
+
+    for idx, mem in enumerate(memories, start=1):
+        main_file = mem['main_file']
+        overlay_file = mem['overlay_file']
+        media_type = mem['media_type']
+        is_video = main_file.suffix.lower() in VIDEO_SUFFIXES
+
+        # Apply media-type / overlay filters.
+        if (videos_only and not is_video) or (pictures_only and is_video) or \
+                (overlays_only and overlay_file is None):
+            skipped_count += 1
+            continue
+
+        # Output filename: timestamp-based, or the export's clean base (no -main).
+        if use_timestamp_filenames and mem['date'] != 'Unknown':
+            out_name = generate_filename(mem['date'], main_file.suffix, True, f"{idx:02d}")
+        else:
+            out_name = main_file.name.replace('-main', '')
+        out_file = output_path / out_name
+
+        print(f"\n[{idx}/{len(memories)}] {main_file.name}")
+        print(f"  Date: {mem['date']} | Type: {media_type} | "
+              f"Location: {mem['latitude']}, {mem['longitude']}")
+        if overlay_file:
+            print(f"  Overlay: {overlay_file.name}")
+
+        entry = {
+            'number': idx,
+            'date': mem['date'],
+            'media_type': media_type,
+            'latitude': mem['latitude'],
+            'longitude': mem['longitude'],
+            'source_main': main_file.name,
+            'source_overlay': overlay_file.name if overlay_file else None,
+        }
+
+        try:
+            did_merge = False
+            if is_video:
+                if overlay_file and merge_overlays:
+                    if ffmpeg_available:
+                        print("  Merging video overlay (this may take a while)...")
+                        if merge_video_overlay(main_file, overlay_file, out_file):
+                            did_merge = True
+                        else:
+                            print("  Video merge failed; copying main file instead")
+                            shutil.copy2(main_file, out_file)
+                    else:
+                        print("  FFmpeg unavailable; copying main file (overlay kept separate)")
+                        shutil.copy2(main_file, out_file)
+                        shutil.copy2(overlay_file, output_path / overlay_file.name.replace('-main', ''))
+                else:
+                    shutil.copy2(main_file, out_file)
+                # Embed creation time + GPS into the video container.
+                update_video_metadata(out_file, mem['date'], mem['latitude'],
+                                      mem['longitude'], use_local_timezone)
+            else:
+                with open(main_file, 'rb') as f:
+                    image_data = f.read()
+                if overlay_file and merge_overlays:
+                    if Image is not None:
+                        with open(overlay_file, 'rb') as f:
+                            overlay_data = f.read()
+                        image_data = merge_image_overlay(image_data, overlay_data)
+                        did_merge = True
+                    else:
+                        print("  Pillow unavailable; copying main image without merge")
+                # Embed EXIF (GPS + timestamp) regardless of merge.
+                image_data = add_exif_metadata(image_data, mem['date'], mem['latitude'],
+                                               mem['longitude'], use_local_timezone)
+                with open(out_file, 'wb') as f:
+                    f.write(image_data)
+
+            # Preserve capture date as the file's modification time.
+            timestamp = parse_date_to_timestamp(mem['date'], use_local_timezone,
+                                                mem['latitude'], mem['longitude'])
+            if timestamp:
+                set_file_timestamp(out_file, timestamp)
+            else:
+                # Fall back to the original file's mtime.
+                src_stat = main_file.stat()
+                os.utime(out_file, (src_stat.st_atime, src_stat.st_mtime))
+
+            size = out_file.stat().st_size
+            print(f"  {'Merged' if did_merge else 'Saved'}: {out_name} ({size:,} bytes)")
+            entry['status'] = 'success'
+            entry['type'] = 'merged' if did_merge else 'single'
+            entry['files'] = [{'path': out_name, 'size': size,
+                               'type': 'merged' if did_merge else 'single'}]
+            if did_merge:
+                merged_count += 1
+            else:
+                copied_count += 1
+        except Exception as e:  # noqa: BLE001 - never let one bad file abort the batch
+            print(f"  ERROR: {e}")
+            entry['status'] = 'failed'
+            entry['error'] = str(e)
+            error_count += 1
+
+        metadata_list.append(entry)
+
+    save_metadata(metadata_list, output_path)
+
+    print("\n" + "=" * 60)
+    print("Local export processing complete!")
+    print(f"Summary: {merged_count} merged, {copied_count} copied, "
+          f"{skipped_count} skipped, {error_count} errors")
+    print(f"Output: {output_path}/  (originals in the export were not modified)")
+    return True
+
+
 def download_all_memories(
     html_path: str,
     output_dir: str = 'memories',
@@ -2404,6 +2776,17 @@ if __name__ == '__main__':
         metavar='FOLDER',
         help='Update timezone metadata for already-downloaded files (requires timezonefinder and pytz)'
     )
+    parser.add_argument(
+        '--local-export',
+        action='store_true',
+        help='Process a new-format Snapchat export whose media is bundled locally '
+             '(no download URLs). Auto-detected when an export folder is provided.'
+    )
+    parser.add_argument(
+        '--no-merge',
+        action='store_true',
+        help='In --local-export mode, keep -main/-overlay files separate instead of merging them'
+    )
 
     args = parser.parse_args()
 
@@ -2415,6 +2798,30 @@ if __name__ == '__main__':
     # Handle --update-timezone mode (separate from normal download mode)
     if args.update_timezone:
         update_existing_timezone_metadata(args.update_timezone)
+        sys.exit(0)
+
+    # Handle new export format (2026+): media bundled locally, no download URLs.
+    # Forced with --local-export, or auto-detected for a genuine new-format export
+    # (a folder with *-main.* media plus a memories.html gallery or JSON metadata).
+    export_layout = locate_export_layout(args.html_file)
+    is_new_export = export_layout is not None and (
+        export_layout['gallery_html'] is not None or export_layout['json_file'] is not None
+    )
+    if args.local_export or is_new_export:
+        if export_layout is None:
+            print(f"Error: '{args.html_file}' does not look like a new-format export "
+                  f"(no '*-main.*' media files found).")
+            sys.exit(1)
+        process_local_export(
+            args.html_file,
+            output_dir=(args.output if args.output != 'memories' else 'processed_memories'),
+            merge_overlays=not args.no_merge,
+            use_timestamp_filenames=args.timestamp_filenames,
+            use_local_timezone=args.local_timezone,
+            videos_only=args.videos_only,
+            pictures_only=args.pictures_only,
+            overlays_only=args.overlays_only,
+        )
         sys.exit(0)
 
     html_path = args.html_file

--- a/test_download_memories.py
+++ b/test_download_memories.py
@@ -1030,13 +1030,13 @@ class TestNewExportParsing:
             assert mems[0]['overlay_file'] is not None
             assert mems[1]['overlay_file'] is None
 
-    def test_build_local_memories_falls_back_to_filename_date_on_count_mismatch(self):
+    def test_build_local_memories_falls_back_to_filename_date_when_no_date_match(self):
         with tempfile.TemporaryDirectory() as tmp:
             root = _build_new_export(Path(tmp) / 'export', [
                 {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
                  'media_type': 'Image', 'location': 'Latitude, Longitude: 41.32, -105.57', 'overlay': False},
             ])
-            # Corrupt the JSON to have an extra (misaligned) entry
+            # JSON entries are for completely different dates - no date matches the file.
             jp = root / 'json' / 'memories_history.json'
             jp.write_text(json.dumps({"Saved Media": [
                 {"Date": "2099-01-01 00:00:00 UTC", "Media Type": "Image", "Location": ""},
@@ -1047,6 +1047,38 @@ class TestNewExportParsing:
             # GPS not matched, but timestamp derived from the filename's date prefix
             assert mems[0]['date'].startswith('2026-05-13')
             assert mems[0]['latitude'] == 'Unknown'
+
+    def test_build_local_memories_matches_by_date_when_json_reversed(self):
+        """Regression: real exports list JSON newest-first while files are oldest-first.
+
+        Positional alignment would attach every file the wrong GPS/time; matching by
+        date must stay correct, including same-date items consumed chronologically.
+        """
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2025-06-20_a', 'ext': '.png', 'date': '2025-06-20 17:50:11 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 1.0, 1.0', 'overlay': False},
+                {'base': '2025-07-13_b', 'ext': '.png', 'date': '2025-07-13 10:00:00 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 2.0, 2.0', 'overlay': False},
+                {'base': '2025-07-13_c', 'ext': '.png', 'date': '2025-07-13 11:00:00 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 3.0, 3.0', 'overlay': False},
+                {'base': '2025-08-01_d', 'ext': '.png', 'date': '2025-08-01 09:00:00 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 4.0, 4.0', 'overlay': False},
+            ])
+            # Snapchat orders the JSON newest-first - reverse it to reproduce reality.
+            jp = root / 'json' / 'memories_history.json'
+            data = json.loads(jp.read_text())
+            data['Saved Media'].reverse()
+            jp.write_text(json.dumps(data))
+
+            mems = build_local_memories(locate_export_layout(str(root)))
+            assert len(mems) == 4
+            # Files are in gallery order (chronological); each keeps its own GPS/time.
+            assert (mems[0]['date'], mems[0]['latitude']) == ('2025-06-20 17:50:11 UTC', '1.0')
+            # Same-date pair assigned chronologically (earlier time -> earlier gallery item)
+            assert (mems[1]['date'], mems[1]['latitude']) == ('2025-07-13 10:00:00 UTC', '2.0')
+            assert (mems[2]['date'], mems[2]['latitude']) == ('2025-07-13 11:00:00 UTC', '3.0')
+            assert (mems[3]['date'], mems[3]['latitude']) == ('2025-08-01 09:00:00 UTC', '4.0')
 
 
 class TestProcessLocalExport:

--- a/test_download_memories.py
+++ b/test_download_memories.py
@@ -1107,8 +1107,9 @@ class TestProcessLocalExport:
             # Merged output written without the -main suffix
             produced = out / '2026-05-13_A.png'
             assert produced.exists()
-            img = Image.open(produced)
-            assert img.size == (64, 64)
+            # Context manager closes the handle (Windows can't clean up an open file).
+            with Image.open(produced) as img:
+                assert img.size == (64, 64)
 
             # Originals untouched
             assert (root / 'memories' / '2026-05-13_A-main.png').exists()

--- a/test_download_memories.py
+++ b/test_download_memories.py
@@ -26,7 +26,13 @@ from download_memories import (
     parse_html_file,
     get_timezone_from_gps,
     convert_utc_to_local,
-    timezone_support
+    timezone_support,
+    locate_export_layout,
+    parse_memories_json,
+    parse_gallery_main_order,
+    find_overlay_for_main,
+    build_local_memories,
+    process_local_export,
 )
 
 
@@ -875,6 +881,248 @@ class TestDuplicateDetection:
 
         assert is_dup is False
         assert dup_file is None
+
+
+# ============================================================================
+# New export format (2026+): locally-bundled media (GitHub issue #23)
+# ============================================================================
+
+def _write_png(path, color=(255, 0, 0), size=(64, 64), mode='RGB'):
+    """Write a small PNG to disk and return its raw bytes."""
+    from PIL import Image
+    img = Image.new(mode, size, color=color)
+    img.save(path, format='PNG')
+    return path
+
+
+def _build_new_export(root: Path, items):
+    """Create a synthetic new-format export under `root`.
+
+    items: list of dicts with keys: base (filename stem without -main),
+    ext (e.g. '.png'), date (UTC string), media_type, location, overlay (bool).
+    Returns the export root path.
+    """
+    (root / 'html').mkdir(parents=True, exist_ok=True)
+    (root / 'json').mkdir(parents=True, exist_ok=True)
+    media = root / 'memories'
+    media.mkdir(parents=True, exist_ok=True)
+
+    saved_media = []
+    gallery_blocks = []
+    for it in items:
+        main_name = f"{it['base']}-main{it['ext']}"
+        _write_png(media / main_name, color=(200, 50, 50))
+        if it.get('overlay'):
+            # Overlay is a semi-transparent PNG (matches Snapchat using PNG overlays)
+            _write_png(media / f"{it['base']}-overlay.png", color=(0, 0, 255), mode='RGBA')
+        media_tag = 'video' if it['media_type'] == 'Video' else 'img'
+        gallery_blocks.append(
+            f'<div class="image-container">'
+            f'<{media_tag} src=".//{main_name}"></{media_tag}>'
+            f'<div class="text-line">{it["date"].split(" ")[0]}</div>'
+            f'</div>'
+        )
+        saved_media.append({
+            "Date": it['date'],
+            "Media Type": it['media_type'],
+            "Location": it.get('location', ''),
+            "Download Link": "",
+            "Media Download Url": "",
+        })
+
+    (media / 'memories.html').write_text(
+        '<!DOCTYPE html><html><body><div>' + ''.join(gallery_blocks) + '</div></body></html>',
+        encoding='utf-8',
+    )
+    (root / 'json' / 'memories_history.json').write_text(
+        json.dumps({"Saved Media": saved_media}), encoding='utf-8'
+    )
+    return root
+
+
+class TestNewExportParsing:
+    """Parsing helpers for the new bundled-media export format."""
+
+    def test_parse_memories_json_normalizes_fields(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            jp = Path(tmp) / 'memories_history.json'
+            jp.write_text(json.dumps({"Saved Media": [
+                {"Date": "2026-05-13 05:03:26 UTC", "Media Type": "Video",
+                 "Location": "Latitude, Longitude: 41.322487, -105.57241",
+                 "Download Link": "", "Media Download Url": ""},
+                {"Date": "2026-05-14 10:00:00 UTC", "Media Type": "Image",
+                 "Location": "", "Download Link": "", "Media Download Url": ""},
+            ]}))
+            mems = parse_memories_json(jp)
+            assert len(mems) == 2
+            assert mems[0] == {
+                'date': "2026-05-13 05:03:26 UTC", 'media_type': 'Video',
+                'latitude': '41.322487', 'longitude': '-105.57241',
+            }
+            # Missing location degrades to 'Unknown', not a crash
+            assert mems[1]['latitude'] == 'Unknown'
+            assert mems[1]['longitude'] == 'Unknown'
+
+    def test_parse_gallery_main_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            gp = Path(tmp) / 'memories.html'
+            gp.write_text(
+                '<div class="image-container"><video src=".//A_x-main.mp4"></video></div>'
+                '<div class="image-container"><img src=".//B_y-main.png"></div>'
+            )
+            assert parse_gallery_main_order(gp) == ['A_x-main.mp4', 'B_y-main.png']
+
+    def test_find_overlay_for_main_pairs_by_base(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            media = Path(tmp)
+            main = media / '2026-05-13_UUID-main.mp4'
+            main.write_bytes(b'x')
+            # Overlay uses a different extension than the main file
+            overlay = media / '2026-05-13_UUID-overlay.png'
+            overlay.write_bytes(b'y')
+            assert find_overlay_for_main(main) == overlay
+
+    def test_find_overlay_returns_none_when_absent(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = Path(tmp) / '2026-05-13_UUID-main.mp4'
+            main.write_bytes(b'x')
+            assert find_overlay_for_main(main) is None
+
+    def test_locate_export_layout_detects_root(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_UUID', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 1.0, 2.0', 'overlay': False},
+            ])
+            layout = locate_export_layout(str(root))
+            assert layout is not None
+            assert layout['media_dir'].name == 'memories'
+            assert layout['gallery_html'] is not None
+            assert layout['json_file'] is not None
+
+    def test_locate_export_layout_from_inner_html_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_UUID', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': '', 'overlay': False},
+            ])
+            # Pointing at the bundled gallery file still resolves the export
+            layout = locate_export_layout(str(root / 'memories' / 'memories.html'))
+            assert layout is not None and layout['root'] == root
+
+    def test_locate_export_layout_rejects_non_export(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / 'random.txt').write_text('not an export')
+            assert locate_export_layout(tmp) is None
+
+    def test_build_local_memories_aligns_json_by_order(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 41.32, -105.57', 'overlay': True},
+                {'base': '2026-05-14_B', 'ext': '.png', 'date': '2026-05-14 10:00:00 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 11.0, 22.0', 'overlay': False},
+            ])
+            mems = build_local_memories(locate_export_layout(str(root)))
+            assert len(mems) == 2
+            assert mems[0]['date'] == '2026-05-13 05:03:26 UTC'
+            assert mems[0]['latitude'] == '41.32'
+            assert mems[0]['overlay_file'] is not None
+            assert mems[1]['overlay_file'] is None
+
+    def test_build_local_memories_falls_back_to_filename_date_on_count_mismatch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': 'Latitude, Longitude: 41.32, -105.57', 'overlay': False},
+            ])
+            # Corrupt the JSON to have an extra (misaligned) entry
+            jp = root / 'json' / 'memories_history.json'
+            jp.write_text(json.dumps({"Saved Media": [
+                {"Date": "2099-01-01 00:00:00 UTC", "Media Type": "Image", "Location": ""},
+                {"Date": "2098-01-01 00:00:00 UTC", "Media Type": "Image", "Location": ""},
+            ]}))
+            mems = build_local_memories(locate_export_layout(str(root)))
+            assert len(mems) == 1
+            # GPS not matched, but timestamp derived from the filename's date prefix
+            assert mems[0]['date'].startswith('2026-05-13')
+            assert mems[0]['latitude'] == 'Unknown'
+
+
+class TestProcessLocalExport:
+    """End-to-end processing of a new-format export."""
+
+    def test_returns_false_for_non_export(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            (Path(tmp) / 'foo.txt').write_text('x')
+            out = Path(tmp) / 'out'
+            assert process_local_export(tmp, output_dir=str(out)) is False
+
+    def test_image_overlay_merged_with_exif_and_metadata(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not available")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image',
+                 'location': 'Latitude, Longitude: 41.322487, -105.57241', 'overlay': True},
+            ])
+            out = Path(tmp) / 'out'
+            assert process_local_export(str(root), output_dir=str(out)) is True
+
+            # Merged output written without the -main suffix
+            produced = out / '2026-05-13_A.png'
+            assert produced.exists()
+            img = Image.open(produced)
+            assert img.size == (64, 64)
+
+            # Originals untouched
+            assert (root / 'memories' / '2026-05-13_A-main.png').exists()
+            assert (root / 'memories' / '2026-05-13_A-overlay.png').exists()
+
+            # metadata.json reflects a successful merge
+            meta = json.loads((out / 'metadata.json').read_text())
+            assert len(meta) == 1
+            assert meta[0]['status'] == 'success'
+            assert meta[0]['type'] == 'merged'
+            assert meta[0]['latitude'] == '41.322487'
+
+            # Capture date preserved as the file mtime (UTC)
+            expected = parse_date_to_timestamp('2026-05-13 05:03:26 UTC')
+            assert abs(produced.stat().st_mtime - expected) < 2
+
+    def test_image_without_overlay_is_copied_with_exif(self):
+        try:
+            from PIL import Image
+        except ImportError:
+            pytest.skip("Pillow not available")
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': '', 'overlay': False},
+            ])
+            out = Path(tmp) / 'out'
+            process_local_export(str(root), output_dir=str(out))
+            produced = out / '2026-05-13_A.png'
+            assert produced.exists()
+            meta = json.loads((out / 'metadata.json').read_text())
+            assert meta[0]['type'] == 'single'
+
+    def test_overlays_only_skips_memories_without_overlay(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = _build_new_export(Path(tmp) / 'export', [
+                {'base': '2026-05-13_A', 'ext': '.png', 'date': '2026-05-13 05:03:26 UTC',
+                 'media_type': 'Image', 'location': '', 'overlay': True},
+                {'base': '2026-05-14_B', 'ext': '.png', 'date': '2026-05-14 10:00:00 UTC',
+                 'media_type': 'Image', 'location': '', 'overlay': False},
+            ])
+            out = Path(tmp) / 'out'
+            process_local_export(str(root), output_dir=str(out), overlays_only=True)
+            meta = json.loads((out / 'metadata.json').read_text())
+            assert len(meta) == 1
+            assert meta[0]['source_main'] == '2026-05-13_A-main.png'
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixes #23.

## Background
Snapchat changed its Memories export (~2026). The old `html/memories_history.html` is still present but its **Download column now reads `N/A`** — there are no download URLs anymore. Instead the media is **bundled directly in the export** under `memories/` as `<YYYY-MM-DD>_<UUID>-main.<ext>` (plus optional `-overlay`), with metadata in `json/memories_history.json`. Our URL-based parsers find no links and report *"No memories found in the HTML file"* — that's issue #23.

Snapchat still does **not** merge overlays onto the media, so overlay-merging (this tool's core value-add) is still needed — just from local files instead of downloads.

## What this PR does
Adds a **local-export processing path** to both implementations. Point the tool at the unzipped export folder and it auto-detects the new format, pairs `-main`/`-overlay` by filename, merges overlays, embeds EXIF (images) / container metadata (videos) + GPS/timestamps from the JSON, and writes results — **no network access; originals untouched**.

### Python (`download_memories.py`)
- `locate_export_layout`, `parse_memories_json`, `parse_gallery_main_order`, `find_overlay_for_main`, `build_local_memories`, `process_local_export`
- CLI: auto-detected when given an export folder; `--local-export` to force, `--no-merge` to keep overlay files separate
- Reuses existing merge / EXIF / video-metadata / timestamp helpers; writes to `processed_memories/`

### Web (`docs/index.html`)
- New **"Choose Export Folder"** picker (`<input webkitdirectory>`) → reads the export in-browser, pairs/merges (Canvas + FFmpeg.wasm), embeds EXIF (piexif) + capture-date mtime, downloads a single ZIP. Mirrors the Python logic and reuses the existing merge helpers.

### Metadata matching (the subtle part)
`json/memories_history.json` lists entries **newest-first**, while the gallery/files are **oldest-first**, and the JSON has no filename field. Naive positional alignment mismatches every item. Both sides instead **match by capture date** (group JSON by date, consume each date chronologically) — direction-agnostic, and resolves same-date bursts in order. Files with no date match fall back to the filename date (no GPS).

## Docs
README explains both formats, the folder picker, and that **exports now appear to expire ~3 days after request** (down from ~7) — download promptly.

## Testing
- 62 unit tests pass (added `TestNewExportParsing` / `TestProcessLocalExport`, incl. a **reversed-JSON regression test** and an image+overlay merge fixture).
- Validated end-to-end on two real exports, including a 12-item export with an overlay: all GPS + exact times correct, same-date pairs ordered right, overlay visually composited, EXIF/video metadata embedded.
- Web folder picker verified in **headless Chrome**: folder ingest → Canvas merge → piexif EXIF → ZIP download, all correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)