### PR TITLE
Add community health files (CoC, contributing, security, templates)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Something isn't working
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug! Please **don't** attach real
+        Snapchat memories, download URLs, or GPS coordinates — redact or use
+        synthetic samples.
+  - type: dropdown
+    id: version
+    attributes:
+      label: Which version?
+      options:
+        - Web (browser, GitHub Pages)
+        - Python CLI (download_memories.py)
+        - Python GUI (snapchat_memories_gui.py)
+    validations:
+      required: true
+  - type: dropdown
+    id: export-format
+    attributes:
+      label: Which export format do you have?
+      description: |
+        Open your export. Does `memories_history.html` have **Download** links, or is
+        your media already inside a **`memories/`** folder (no links)?
+      options:
+        - "Older: memories_history.html has Download links"
+        - "Newer (~2026): media is bundled in a memories/ folder (no links)"
+        - "Not sure"
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug, including any error message.
+      placeholder: When I ... the tool ...
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. Go to ...
+        2. Click / run ...
+        3. See error ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: false
+  - type: input
+    id: os
+    attributes:
+      label: Operating system
+      placeholder: "e.g. Windows 11, macOS 14, Ubuntu 24.04"
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Browser (web) or Python version (CLI/GUI)
+      placeholder: "e.g. Chrome 124 / Firefox 126 — or Python 3.12"
+    validations:
+      required: false
+  - type: textarea
+    id: logs
+    attributes:
+      label: Logs / console output
+      description: |
+        Web: open DevTools → Console and paste relevant output.
+        Python: paste the terminal output. **Remove any URLs or coordinates.**
+      render: shell
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Search existing issues first
+    url: https://github.com/andrefecto/Snapchat-Memories-Downloader/issues?q=is%3Aissue
+    about: Your question may already be answered — please search before opening a new issue.
+  - name: README & usage guide
+    url: https://github.com/andrefecto/Snapchat-Memories-Downloader#readme
+    about: Setup, options, and how to get your Snapchat data.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,45 @@
+name: Feature request
+description: Suggest an idea or improvement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem would this solve?
+      description: What are you trying to do that's hard or impossible today?
+      placeholder: I'm always frustrated when ...
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: What would you like to happen?
+    validations:
+      required: true
+  - type: dropdown
+    id: target
+    attributes:
+      label: Which version is this for?
+      multiple: true
+      options:
+        - Web (browser)
+        - Python CLI
+        - Python GUI
+        - Either / both
+    validations:
+      required: false
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Anything else — mockups, links, examples (no personal data, please).
+    validations:
+      required: false

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,34 @@
+<!-- Thanks for contributing! Please fill out the sections below. -->
+
+## Summary
+
+<!-- What does this PR do, and why? -->
+
+Fixes #<!-- issue number, if applicable -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Documentation
+- [ ] Refactor / chore
+
+## Affected version(s)
+
+- [ ] Web (`docs/index.html`)
+- [ ] Python CLI (`download_memories.py`)
+- [ ] Python GUI (`snapchat_memories_gui.py`)
+
+## How was this tested?
+
+<!-- Commands you ran, manual steps, export format used, etc.
+     Don't paste real memories, URLs, or GPS data. -->
+
+## Checklist
+
+- [ ] I read the [Contributing guide](../CONTRIBUTING.md).
+- [ ] Tests pass locally (`pytest test_download_memories.py`).
+- [ ] I added/updated tests for my change (if applicable).
+- [ ] I kept the web and Python versions in sync where it made sense.
+- [ ] I updated the README / `CHANGELOG.md` for user-facing changes (if applicable).
+- [ ] No analytics, telemetry, or off-device data transmission was introduced.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,85 @@
+
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, color, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at the project maintainer [@andrefecto](https://github.com/andrefecto) (open a private report via the repository's **Security** tab, or contact the maintainer through GitHub). All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 2.1, available at [https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at [https://www.contributor-covenant.org/faq][FAQ]. Translations are available at [https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations
+

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,83 @@
+# Contributing
+
+Thanks for your interest in improving the Snapchat Memories Downloader! This is a
+free, privacy-first tool and contributions are welcome.
+
+By participating you agree to abide by our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Ways to contribute
+
+- **Report a bug** — open a [bug report](https://github.com/andrefecto/Snapchat-Memories-Downloader/issues/new/choose).
+- **Request a feature** — open a [feature request](https://github.com/andrefecto/Snapchat-Memories-Downloader/issues/new/choose).
+- **Send a pull request** — fixes and improvements are appreciated (see below).
+
+When reporting a problem with your export, please say whether your
+`memories_history.html` has **Download links** (older format) or whether your media
+is already bundled in a **`memories/` folder** (newer ~2026 format). It helps a lot
+with triage. Never attach real memories, download URLs, or GPS data to an issue.
+
+## Project layout
+
+This repo ships two implementations that share the same workflow:
+
+- **Python CLI** — `download_memories.py` (+ `snapchat_memories_gui.py` for the PyQt6 GUI)
+- **Web** — `docs/index.html`, a single self-contained file served via GitHub Pages
+
+See [CLAUDE.md](CLAUDE.md) for an architecture overview.
+
+## Development setup (Python)
+
+```bash
+./setup.sh                 # create venv + install dependencies
+source venv/bin/activate
+pip install pytest pytest-cov pytest-xdist   # test tooling
+```
+
+Requirements: **Python 3.11+**. Video overlay merging needs **FFmpeg** installed and
+on your `PATH` (`brew install ffmpeg`, `apt-get install ffmpeg`, or `choco install ffmpeg`).
+
+### Running the tests
+
+```bash
+pytest test_download_memories.py -v
+```
+
+Please add or update tests for any behavior you change. Tests must pass on the
+supported matrix (Python 3.11 / 3.12 on Linux, macOS, and Windows) — CI runs this
+automatically on every pull request.
+
+### Quick manual check
+
+```bash
+python3 download_memories.py --test          # processes the first 3 items only
+python3 download_memories.py /path/to/export # auto-detects a new bundled export
+```
+
+## Development setup (Web)
+
+There is **no build step**. Edit `docs/index.html` directly and open it in a browser
+(or serve the `docs/` folder) to test. The FFmpeg.wasm artifacts under `docs/ffmpeg/`
+are synced automatically by CI when `package.json` updates — don't edit them by hand.
+
+> The web version needs cross-origin isolation for FFmpeg.wasm. If you serve it
+> locally, send `Cross-Origin-Opener-Policy: same-origin` and
+> `Cross-Origin-Embedder-Policy: require-corp` headers.
+
+## Pull request guidelines
+
+1. Fork the repo and create a branch from `main`.
+2. Keep changes focused; match the style and comment density of the surrounding code.
+3. If you change the Python tool, keep the **web** version in sync where it makes
+   sense (and vice-versa) — they're meant to behave the same.
+4. Add tests and make sure `pytest` passes locally.
+5. Update the README / `CHANGELOG.md` when you add or change user-facing behavior.
+6. Open the PR and fill out the template. CI must be green before merge.
+
+## Privacy ground rules
+
+This tool is built so that **your data never leaves your machine**. Please keep it
+that way: no analytics, no telemetry, no network calls beyond downloading a user's
+own memories from Snapchat's own URLs (older format) — and nothing at all for the
+new bundled-export path.
+
+Thank you for contributing! 🎉

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,54 @@
+# Security Policy
+
+## Supported versions
+
+This project is distributed as source you run yourself. Security fixes are made
+against the latest code on the `main` branch (and the live web version on GitHub
+Pages). Please make sure you are running the current version before reporting.
+
+| Version            | Supported |
+| ------------------ | --------- |
+| `main` / latest    | ✅        |
+| older snapshots    | ❌        |
+
+## Reporting a vulnerability
+
+Please **do not** open a public issue for security problems.
+
+Instead, report privately through GitHub's
+[**private vulnerability reporting**](https://github.com/andrefecto/Snapchat-Memories-Downloader/security/advisories/new)
+(the **Security → Report a vulnerability** button on the repository). If that is
+unavailable, contact the maintainer [@andrefecto](https://github.com/andrefecto)
+through GitHub.
+
+When reporting, please include:
+
+- A description of the issue and its potential impact.
+- Steps to reproduce (a minimal proof of concept if possible).
+- The affected version (Python CLI or web) and your OS / browser.
+
+**Never include real Snapchat memories, download URLs, or GPS coordinates in a
+report.** Redact or synthesize sample data.
+
+You can expect an acknowledgement within a reasonable time, and we'll keep you
+updated on the fix. Coordinated disclosure is appreciated — please give us a chance
+to release a fix before publishing details.
+
+## Scope & threat model
+
+This is a **privacy-first, client-side tool**:
+
+- The **web** version runs entirely in your browser — no upload, no server, no
+  analytics.
+- The **Python** version runs entirely on your machine.
+- The only network activity is downloading a user's *own* memories from Snapchat's
+  own URLs (older export format). The new bundled-export path makes **no** network
+  requests at all.
+
+Things especially worth reporting:
+
+- Any code path that would transmit user data off-device.
+- Handling of untrusted input from `memories_history.html` / `memories.html` /
+  `memories_history.json` or downloaded media (e.g. path traversal when writing
+  files, ZIP handling, or magic-byte parsing).
+- Dependency vulnerabilities (Dependabot is enabled, but reports are welcome).


### PR DESCRIPTION
Brings the repo into compliance with GitHub's **Community Standards** checklist
(was at 42% — missing everything except README + license).

## Added
- **CODE_OF_CONDUCT.md** — Contributor Covenant 2.1 (reports routed to the maintainer via GitHub).
- **CONTRIBUTING.md** — dev setup (venv/FFmpeg/Python 3.11+), running tests, the dual web/Python workflow, and the project's privacy ground rules.
- **SECURITY.md** — private vulnerability reporting + a threat model appropriate for a client-side, no-server tool.
- **.github/ISSUE_TEMPLATE/** — `bug_report.yml` and `feature_request.yml` issue forms, plus `config.yml`. The bug form asks **which version (web/Python)** and **which export format** (Download links vs. bundled `memories/` folder) — directly speeds up triage of the new-format reports like #23.
- **.github/pull_request_template.md**.

## Notes
- CoC contact is directed through the maintainer's GitHub / the Security tab rather than a personal email — tell me if you'd prefer a specific email address there.
- `blank_issues_enabled: false` nudges people to the templates; the "search first" and README links replace a Discussions link (Discussions isn't enabled).

After merge, the repository's Community Standards page should report 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)