### PR TITLE
ci: reliable Windows FFmpeg (drop flaky setup-ffmpeg action)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,7 @@ jobs:
         pip install pytest pytest-cov pytest-xdist
 
     # Linux/macOS: the OS package manager is fast and ships a build that passes
-    # the video-merge tests. Windows: `choco install ffmpeg` is the slow step
-    # (~2-3 min), so use the cached setup-ffmpeg action there instead.
+    # the video-merge tests.
     - name: Install FFmpeg (Ubuntu)
       if: runner.os == 'Linux'
       run: |
@@ -54,9 +53,28 @@ jobs:
       run: |
         brew install ffmpeg
 
+    # Windows: `choco install ffmpeg` was the slow step (~2-3 min). Download a
+    # prebuilt static build directly from GitHub (reliable CDN) with retries,
+    # instead of the unmaintained setup-ffmpeg action (which flaked with
+    # "fetch failed" and is pinned to the soon-deprecated Node 20).
     - name: Install FFmpeg (Windows)
       if: runner.os == 'Windows'
-      uses: federicocarboni/setup-ffmpeg@v3
+      shell: pwsh
+      run: |
+        $ErrorActionPreference = 'Stop'
+        $url = 'https://github.com/BtbN/FFmpeg-Builds/releases/download/latest/ffmpeg-master-latest-win64-gpl.zip'
+        $zip = "$env:RUNNER_TEMP\ffmpeg.zip"
+        $dst = "$env:RUNNER_TEMP\ffmpeg"
+        for ($i = 1; $i -le 4; $i++) {
+          try { Invoke-WebRequest -Uri $url -OutFile $zip -UseBasicParsing -TimeoutSec 120; break }
+          catch { if ($i -eq 4) { throw }; Write-Host "Download failed (attempt $i), retrying..."; Start-Sleep -Seconds 15 }
+        }
+        Expand-Archive -Path $zip -DestinationPath $dst -Force
+        $bin = (Get-ChildItem -Path $dst -Recurse -Filter ffmpeg.exe | Select-Object -First 1).DirectoryName
+        if (-not $bin) { throw "ffmpeg.exe not found after extraction" }
+        "$bin" | Out-File -FilePath $env:GITHUB_PATH -Append -Encoding utf8
+        & "$bin\ffmpeg.exe" -version | Select-Object -First 1
+        & "$bin\ffprobe.exe" -version | Select-Object -First 1
 
     - name: Run test suite
       run: |


### PR DESCRIPTION
The `setup-ffmpeg` action introduced in the last CI change flaked on Windows with `TypeError: fetch failed` (it failed `main` after the SECURITY.md commit), and it's unmaintained + pinned to **Node 20**, which GitHub force-deprecates on **2026-06-16**.

This replaces it with a direct download of a prebuilt static FFmpeg from **BtbN's GitHub release** (reliable GitHub CDN) with **4 retries**. Fast, no third-party action, and Linux/macOS keep `apt`/`brew`. Verifies both `ffmpeg` and `ffprobe` after install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)