### PR TITLE
Potential fix for code scanning alert no. 49: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 concurrency:
   group: tests-${{ github.ref }}
   cancel-in-progress: false


### PR DESCRIPTION
Potential fix for [https://github.com/andrefecto/Snapchat-Memories-Downloader/security/code-scanning/49](https://github.com/andrefecto/Snapchat-Memories-Downloader/security/code-scanning/49)

Add an explicit `permissions` block to the workflow root (best here since there is one job and all current/future jobs should default to least privilege).  
For this workflow, the minimal safe scope is:

- `contents: read` (needed for checkout/read access)

No write scopes are required by the shown steps. This preserves existing behavior while limiting token privileges.

Edit `.github/workflows/test.yml` by inserting `permissions:` between the `on:` triggers and `concurrency:` block.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
